### PR TITLE
Support targets with single dest file where the task gets triggered when one of the src files was changed

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     mochaTest: {
       test: {
         options: {
-          reporter: 'spec',
+          reporter: 'spec'
         },
         src: [testSrc]
       }

--- a/lib/util.js
+++ b/lib/util.js
@@ -140,10 +140,18 @@ var filterFilesByHash = exports.filterFilesByHash = function(
       if (obj.dest && !fs.existsSync(obj.dest)) {
         done(null, obj);
       } else if (src && src.length > 0) {
-        done(null, {
-          src: src,
-          dest: obj.dest
-        });
+        if (
+            obj.dest && !(obj.src.length === 1 && obj.dest === obj.src[0])
+        ) {
+          done(null, obj);
+        } else {
+          done(
+              null, {
+                src: src,
+                dest: obj.dest
+              }
+          );
+        }
       } else {
         done(null, null);
       }

--- a/test/integration/changed-single-dest.spec.js
+++ b/test/integration/changed-single-dest.spec.js
@@ -1,0 +1,23 @@
+var path = require('path');
+
+var helper = require('../helper');
+
+var name = 'changed-single-dest';
+var gruntfile = path.join(name, 'gruntfile.js');
+
+describe(name, function() {
+  var fixture;
+
+  it('runs the default task (see ' + gruntfile + ')', function(done) {
+    this.timeout(6000);
+    helper.buildFixture(name, function(error, dir) {
+      fixture = dir;
+      done(error);
+    });
+  });
+
+  after(function(done) {
+    helper.afterFixture(fixture, done);
+  });
+
+});

--- a/test/integration/fixtures/changed-single-dest/gruntfile.js
+++ b/test/integration/fixtures/changed-single-dest/gruntfile.js
@@ -1,0 +1,74 @@
+var path = require('path');
+
+
+/**
+ * @param {Object} grunt Grunt.
+ */
+module.exports = function(grunt) {
+
+  var log = [];
+
+  grunt.initConfig({
+    changed: {
+      options: {
+        cache: path.join(__dirname, '.cache')
+      }
+    },
+    modified: {
+      one: {
+        src: 'src/one.js',
+        dest: 'dist/dest.js'
+      },
+      all: {
+        src: 'src/**/*.js',
+        dest: 'dist/dest.js'
+      },
+      none: {
+        src: [],
+        dest: 'dist/dest.js'
+      }
+    },
+    log: {
+      all: {
+        src: 'src/**/*.js',
+        dest: 'dist/dest.js',
+        getLog: function() {
+          return log;
+        }
+      }
+    },
+    assert: {
+      that: {
+        getLog: function() {
+          return log;
+        }
+      }
+    }
+  });
+
+  grunt.loadTasks('../../../tasks');
+  grunt.loadTasks('../../../test/integration/tasks');
+
+  grunt.registerTask('default', function() {
+
+    grunt.task.run([
+      // run the assert task with changed, expect all files
+      'changed:log',
+      'assert:that:modified:all',
+
+      // modify one file
+      'modified:one',
+
+      // run assert task again, expect one file
+      'changed:log',
+      'assert:that:modified:all',
+
+      // modify nothing, expect no files
+      'changed:log',
+      'assert:that:modified:none'
+
+    ]);
+
+  });
+
+};

--- a/test/integration/fixtures/changed-single-dest/src/one.js
+++ b/test/integration/fixtures/changed-single-dest/src/one.js
@@ -1,0 +1,1 @@
+var one = 'one';

--- a/test/integration/fixtures/changed-single-dest/src/two.js
+++ b/test/integration/fixtures/changed-single-dest/src/two.js
@@ -1,0 +1,1 @@
+var two = 'two';


### PR DESCRIPTION
This supports for example uglifying with mangle: true
Should fix https://github.com/researchgate/grunt-changed/issues/7
